### PR TITLE
Declared @types/lodash as ~ dependency to fix issue with WeakMap type

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "chai": "3.5.0",
     "mocha": "3.2.0",
     "tslint": "4.0.2",
-    "typescript": "2.0.10"
+    "typescript": "~2.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@types/bluebird": "3.0.36",
-    "@types/lodash": "4.14.42",
+    "@types/lodash": "~4.14.42",
     "@types/reflect-metadata": "0.0.5",
     "bluebird": "3.4.6",
     "es6-shim": "0.35.2",


### PR DESCRIPTION
I am using [soap-decorators](https://www.npmjs.com/package/soap-decorators)@1.0.2 which depends on xml-decorators.

The binding to @types/lodash pinned to 4.14.42 causes an error in TSC.

Check https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14324 for the discussion of the error that occured.

- [ ] Upgrade the dependency on xml-typescript in [soap-decorators](https://github.com/RobinBuschmann/soap-typescript)